### PR TITLE
Add Quake color support for server names

### DIFF
--- a/public/js/quakecolor.js
+++ b/public/js/quakecolor.js
@@ -1,0 +1,56 @@
+(function (root) {
+
+var quakeColor = root.quakeColor = {};
+
+function htmlEscape(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}
+
+function isAlphaNum(c) {
+    var code = c.charCodeAt(0);
+    return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+// last color is white
+var colorList = ["black", "red", "green", "yellow", "blue", "cyan", "magenta", ""];
+
+function htmlEscapeWithColor(s) {
+  var i = 0;
+  var ret = '';
+  var color = '';
+  var prev = 0;
+  function addSpan(start, end) {
+    var spanText = s.slice(start, end);
+    if (!spanText) return;
+    var escapedSpanText = htmlEscape(spanText);
+    if (color) {
+        ret += '<span style="color:' + color + '">' + escapedSpanText + '</span>';
+    } else {
+        ret += escapedSpanText;
+    }
+  }
+  while (i < s.length) {
+    if (s[i] == '^' && i+1 < s.length && isAlphaNum(s[i+1])) {
+      addSpan(prev, i);
+
+      // Update current color
+      var colorIndex = (s[i+1].charCodeAt(0) - '0'.charCodeAt(0)) & 0x7;
+      color = colorList[colorIndex];
+      i += 2;
+      prev = i;
+    } else {
+      i++;
+    }
+  }
+  addSpan(prev, i);
+  return ret;
+}
+
+quakeColor.htmlEscapeWithColor = htmlEscapeWithColor;
+
+})(this);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -3,6 +3,7 @@
 <% script(furl('/js/dashboard.js')) -%>
 <% script(furl('/js/master.js')) -%>
 <% script(furl('/js/practice.js')) -%>
+<% script(furl('/js/quakecolor.js')) -%>
 <% script(furl('/js/vendor/ejs.min.js')) -%>
 <% script(furl('/js/vendor/spin.min.js')) -%>
 

--- a/views/server.ejs
+++ b/views/server.ejs
@@ -1,6 +1,6 @@
 <td><%= info.ping %></td>
 <td><%= info.gamename %></td>
-<td><%= info.sv_hostname %></td>
+<td><%= quakeColor.htmlEscapeWithColor(info.sv_hostname) %></td>
 <td><%= info.mapname %></td>
 <td><%= info.players.length %> / <%= info.sv_maxclients %></td>
 <td><span>Join&nbsp;<i class="icon-chevron-right"></i></span></td>


### PR DESCRIPTION
Translates Quake color tags, such as "^1" for red, into html span's of the appropriate color.