### PR TITLE
Separate humans players and bots in server display

### DIFF
--- a/public/js/master.js
+++ b/public/js/master.js
@@ -27,7 +27,7 @@ master._stripOOB = function (buffer) {
 	var i_end = buffer.byteLength;
 
 	/* ignore trailing whitespace */
-	while (i_end > 4 && view.getUint8(i_end - 1) <= 32) {
+	while (i_end > i_start && view.getUint8(i_end - 1) <= ' '.charCodeAt(0)) {
 		--i_end;
 	}
 

--- a/public/js/master.js
+++ b/public/js/master.js
@@ -130,7 +130,6 @@ master._parseInfoResponse = function (data) {
 	// Compute the number of bots for the template
 	info.g_botplayers = info.clients - info.g_humanplayers;
 
-	console.log("RETURNING INFO:", info);
 	return info;
 };
 

--- a/views/server.ejs
+++ b/views/server.ejs
@@ -1,6 +1,7 @@
 <td><%= info.ping %></td>
-<td><%= info.gamename %></td>
-<td><%= info.sv_hostname %></td>
+<td><%= info.game ? info.game : "baseq3" %></td>
+<td><%= info.hostname %></td>
 <td><%= info.mapname %></td>
-<td><%= info.players.length %> / <%= info.sv_maxclients %></td>
+<td style="text-align: center"><%= info.g_humanplayers %> / <%= info.g_botplayers %> / <%= info.sv_maxclients %>
+</td>
 <td><span>Join&nbsp;<i class="icon-chevron-right"></i></span></td>

--- a/views/server.ejs
+++ b/views/server.ejs
@@ -2,6 +2,10 @@
 <td><%= info.game ? info.game : "baseq3" %></td>
 <td><%= quakeColor.htmlEscapeWithColor(info.hostname) %></td>
 <td><%= info.mapname %></td>
-<td style="text-align: center"><%= info.g_humanplayers %> / <%= info.g_botplayers %> / <%= info.sv_maxclients %>
+<td>
+  <%= info.g_humanplayers %> / <%= info.sv_maxclients %>
+  <% if (info.g_botplayers > 0) { %>
+    <span style="color: #666666">+ <%= info.g_botplayers %> bot<%= info.g_botplayers > 1 ? "s" : "" %></span>
+  <% } %>
 </td>
 <td><span>Join&nbsp;<i class="icon-chevron-right"></i></span></td>

--- a/views/servers.ejs
+++ b/views/servers.ejs
@@ -7,7 +7,7 @@
 			<th>Game</th>
 			<th>Name</th>
 			<th>Map</th>
-			<th>Players</th>
+			<th style="text-align: center">Players / Bots / Max</th>
 			<th>&nbsp;</th>
 		</tr>
 	</thead>

--- a/views/servers.ejs
+++ b/views/servers.ejs
@@ -7,7 +7,7 @@
 			<th>Game</th>
 			<th>Name</th>
 			<th>Map</th>
-			<th style="text-align: center">Players / Bots / Max</th>
+			<th>Players</th>
 			<th>&nbsp;</th>
 		</tr>
 	</thead>


### PR DESCRIPTION
Needed to switch to using "getinfo" instead of "getstatus". For some reason, getstatus doesn't include g_humanplayers. The code to parse getstatus responses is still present, moved to _parseStatusResponse.

Also, modified _stripOOB to avoid cutting off the last character when it is not whitespace (as is the case with "getinfo")