### PR TITLE
Add HTML escaping on untrusted server-provided text

### DIFF
--- a/public/js/htmlescape.js
+++ b/public/js/htmlescape.js
@@ -1,0 +1,8 @@
+function htmlEscape(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/public/js/quakecolor.js
+++ b/public/js/quakecolor.js
@@ -2,15 +2,6 @@
 
 var quakeColor = root.quakeColor = {};
 
-function htmlEscape(s) {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}
-
 function isAlphaNum(c) {
     var code = c.charCodeAt(0);
     return (code >= 48 && code <= 57) || (code >= 65 && code <= 90) || (code >= 97 && code <= 122);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -4,6 +4,7 @@
 <% script(furl('/js/master.js')) -%>
 <% script(furl('/js/practice.js')) -%>
 <% script(furl('/js/quakecolor.js')) -%>
+<% script(furl('/js/htmlescape.js')) -%>
 <% script(furl('/js/vendor/ejs.min.js')) -%>
 <% script(furl('/js/vendor/spin.min.js')) -%>
 

--- a/views/server.ejs
+++ b/views/server.ejs
@@ -1,9 +1,9 @@
-<td><%= info.ping %></td>
-<td><%= info.game ? info.game : "baseq3" %></td>
+<td><%= htmlEscape(info.ping) %></td>
+<td><%= htmlEscape(info.game ? info.game : "baseq3") %></td>
 <td><%= quakeColor.htmlEscapeWithColor(info.hostname) %></td>
-<td><%= info.mapname %></td>
+<td><%= htmlEscape(info.mapname) %></td>
 <td>
-  <%= info.g_humanplayers %> / <%= info.sv_maxclients %>
+  <%= htmlEscape(info.g_humanplayers) %> / <%= htmlEscape(info.sv_maxclients) %>
   <% if (info.g_botplayers > 0) { %>
     <span style="color: #666666">+ <%= info.g_botplayers %> bot<%= info.g_botplayers > 1 ? "s" : "" %></span>
   <% } %>


### PR DESCRIPTION
Since "ejs.min.js" does not do escaping, do it manually. Minimal change required.